### PR TITLE
Updates to migtools / kubev2v / konveyor repos

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1,12 +1,20 @@
 {
   "repos": [
     {
-      "git": "https://github.com/konveyor/mig-ui",
+      "git": "https://github.com/migtools/mig-ui",
       "name": "Migration-Toolkit-for-Containers"
     },
     {
-      "git": "https://github.com/konveyor/lib-ui",
-      "name": "Konveyor-Shared-Library"
+      "git": "https://github.com/kubev2v/forklift-console-plugin",
+      "name": "Migration-Toolkit-for-Virtualization"
+    },
+    {
+      "git": "https://github.com/konveyor/tackle2-ui",
+      "name": "Migration-Toolkit-For-Applications"
+    },
+    {
+      "git": "https://github.com/migtools/lib-ui",
+      "name": "Migration-Tools-Shared-Library"
     },
     {
       "git": "git@github.com:ansible/awx-pf.git",


### PR DESCRIPTION
Some reorganization is happening in Migration Toolkit land as the upstream Konveyor org is being [donated to the CNCF Sandbox](https://www.konveyor.io/blog/konveyor-is-a-cncf-sandbox-project/). Konveyor is being refocused on the Tackle project (formerly Migration Toolkit for Applications), which wasn't tracked here yet. Other Konveyor projects that are not becoming part of CNCF are gradually being moved to a new github org called "migtools". The Migration Toolkit for Virtualization project (Forklift) has also been moved from Konveyor to a new org "kubev2v", where it has been rebuilt as a dynamic plugin for OpenShift. There are also a couple of repos that weren't tracked yet that I've added here.