### PR TITLE
clean up data, add _all_product_uses report

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -165,7 +165,7 @@
     },
     {
       "git": "https://github.com/syndesisio/syndesis",
-      "name": "Fuse-Online(Syndesis)"
+      "name": "Fuse-Online-Syndesis"
     },
     {
       "git": "https://github.com/apache/activemq-artemis",

--- a/src/html-analysis/crawler.js
+++ b/src/html-analysis/crawler.js
@@ -95,7 +95,7 @@ async function crawl(options) {
   console.log('Waiting for idle');
   await cluster.idle();
   await cluster.close();
-  const reportPath = path.join(statsDir, `/${new Date().toISOString().substr(0, 10)}/`, options.name, '/report.json');
+  const reportPath = path.join(statsDir, `/${new Date().toISOString().substring(0, 10)}/`, options.name, '/report.json');
   fs.ensureFileSync(reportPath);
   fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
   process.exit(exitCode);

--- a/src/static-analysis/cli.js
+++ b/src/static-analysis/cli.js
@@ -2,7 +2,7 @@ const path = require('path');
 const { execSync } = require('child_process');
 const fs = require('fs-extra');
 // IMPORT FUNCTIONS FROM THIS DIRECTORY
-const { getPatternflyStats, patternflyAggs } = require('./getPatternflyStats');
+const { getPatternflyStats, patternflyAggs, productUsage } = require('./getPatternflyStats');
 const { getPackageStats, getAggregatePackageStats } = require('./getPackageStats');
 const { getSortedImports } = require('./getSortedImports');
 // IMPORT JSON LIST OF REPOS
@@ -20,7 +20,7 @@ function collectPatternflyStats(argv) {
   const date = new Date().toISOString();
   // CREATE NEW DIRECTORY W/TODAY'S DATE FOR REPORT
   // STATS-STATIC/{DATE}
-  const dir = `${statsDir}/${date.substr(0, 10)}`;
+  const dir = `${statsDir}/${date.substring(0, 10)}`;
   if (argv.c) {
     fs.removeSync(tmpDir);
   }
@@ -37,7 +37,7 @@ function collectPatternflyStats(argv) {
         : `git clone "${repo.git}" "${tmpPath}" --depth 1`;
       console.log(command);
       execSync(command);
-      const patternflyStats = getPatternflyStats(tmpPath);
+      const patternflyStats = getPatternflyStats(tmpPath, repo.name);
       patternflyStats.repo = repo.git;
       patternflyStats.name = repo.name || repoName;
       patternflyStats.date = date;
@@ -51,6 +51,7 @@ function collectPatternflyStats(argv) {
     fs.outputFileSync(`${dir}/_all_dependencies.json`, JSON.stringify(getAggregatePackageStats(), null, 2));
     fs.outputFileSync(`${dir}/_all.json`, JSON.stringify(patternflyAggs, null, 2));
     fs.outputFileSync(`${dir}/_all_sorted.json`, JSON.stringify(getSortedImports(patternflyAggs.imports), null, 2));
+    fs.outputFileSync(`${dir}/_all_product_uses.json`, JSON.stringify(productUsage, null, 2));
   }
   console.log(`Collected stats for ${date} under ${dir}`);
 }

--- a/src/static-analysis/cli.js
+++ b/src/static-analysis/cli.js
@@ -4,7 +4,7 @@ const fs = require('fs-extra');
 // IMPORT FUNCTIONS FROM THIS DIRECTORY
 const { getPatternflyStats, patternflyAggs, productUsage } = require('./getPatternflyStats');
 const { getPackageStats, getAggregatePackageStats } = require('./getPackageStats');
-const { getSortedImports } = require('./getSortedImports');
+const { getSortedImports, getSortedUsage } = require('./getSortedImports');
 // IMPORT JSON LIST OF REPOS
 const repos = require('../../repos.json').repos;
 
@@ -51,7 +51,7 @@ function collectPatternflyStats(argv) {
     fs.outputFileSync(`${dir}/_all_dependencies.json`, JSON.stringify(getAggregatePackageStats(), null, 2));
     fs.outputFileSync(`${dir}/_all.json`, JSON.stringify(patternflyAggs, null, 2));
     fs.outputFileSync(`${dir}/_all_sorted.json`, JSON.stringify(getSortedImports(patternflyAggs.imports), null, 2));
-    fs.outputFileSync(`${dir}/_all_product_uses.json`, JSON.stringify(productUsage, null, 2));
+    fs.outputFileSync(`${dir}/_all_product_uses.json`, JSON.stringify(getSortedUsage(productUsage), null, 2));
   }
   console.log(`Collected stats for ${date} under ${dir}`);
 }

--- a/src/static-analysis/getPackageStats.js
+++ b/src/static-analysis/getPackageStats.js
@@ -118,7 +118,7 @@ function getPackageStats(repoPath, repoName) {
         const date = new Date().toISOString();
         const statsDir = path.resolve(__dirname, '../../stats-static');
 
-        fsj.writeFileSync(`${statsDir}/${date.substr(0, 10)}/${repoName}-${extractFilename(filePath)}-data.csv`, data, "utf-8", (err) => {
+        fsj.writeFileSync(`${statsDir}/${date.substring(0, 10)}/${repoName}-${extractFilename(filePath)}-data.csv`, data, "utf-8", (err) => {
           if (err) console.log(err);
           else console.log("Data saved");
         });

--- a/src/static-analysis/getPatternflyStats.js
+++ b/src/static-analysis/getPatternflyStats.js
@@ -75,12 +75,23 @@ function getPatternflyStats(repoPath, repoName) {
       patternflyAggs.classes[className] = patternflyAggs.classes[className] || 0;
       patternflyAggs.classes[className]++;
       // update productUsage
-      productUsage.classes[className] = productUsage.classes[className] || {};
-      productUsage.classes[className][repoName] = productUsage.classes[className][repoName] || [];
-      productUsage.classes[className][repoName].push(fileName);
+      productUsage.classes[className] = productUsage.classes[className] || {
+        "product_count": 0,
+        "total_usage": 0
+      };
+      const classDataObj = productUsage.classes[className];
+      if (!classDataObj[repoName]) {
+        classDataObj[repoName] = { "repo_usage": 0 };
+        classDataObj.product_count++;
+      }
+      classDataObj[repoName][fileName] = classDataObj[repoName][fileName] || 0;
+      classDataObj[repoName][fileName]++;
+      classDataObj[repoName].repo_usage++;
+      classDataObj.total_usage++;
     }
   }
 
+  // Check for /deprecated && /next, update component name to avoid counting as current component
   // Build { result: { imports } }
   jsFiles.forEach(file => {
     const stat = fs.lstatSync(file);
@@ -105,17 +116,37 @@ function getPatternflyStats(repoPath, repoName) {
         .forEach(imp => {
           const pkgName = regMatch[2];
           let pkg = result.imports[pkgName];
+          // update component name if deprecated or next component
+          if (pkgName.includes('/deprecated')) {
+            imp = `${imp}-deprecated`;
+          } else if (pkgName.includes('/next')) {
+            imp = `${imp}-next`;
+          }
           pkg[imp] = pkg[imp] || 0;
           pkg[imp]++;
           pkg = patternflyAggs.imports[pkgName];
           pkg[imp] = pkg[imp] || 0;
           pkg[imp]++;
           // product usage
-          productUsage.imports[pkgName] = productUsage.imports[pkgName] || {};
-          pkg = productUsage.imports[pkgName];
-          pkg[imp] = pkg[imp] || {};
-          pkg[imp][repoName] = pkg[imp][repoName] || [];
-          pkg[imp][repoName].push(fileName);
+          productUsage.imports[imp] = productUsage.imports[imp] || { "product_count": 0, "total_usage": 0 };
+          let component = productUsage.imports[imp]; // Card
+          // Increment product count if repo not yet tracked
+          if (!component[repoName]) {
+            component.product_count++;
+            component[repoName] = {
+              "unique_import_paths": 0,
+              "repo_usage": 0
+            };
+          }
+          // Increment package import count if new import path
+          if (!component[repoName][pkgName]) {
+            component[repoName][pkgName] = {};
+            component[repoName].unique_import_paths++;
+          }
+          component[repoName][pkgName][fileName] = component[repoName][pkgName][fileName] || 0;
+          component[repoName][pkgName][fileName]++;
+          component[repoName].repo_usage++;
+          component.total_usage++;
         });
     }
 
@@ -137,17 +168,30 @@ function getPatternflyStats(repoPath, repoName) {
         fileName = file.replace(repoPath, '')
         result.files.withPatternfly[ext][fileName] = true;
       }
+      // Variable to report on
       const cssVarName = regMatch[1];
+      // Track for repo's json
       result.cssVars[cssVarName] = result.cssVars[cssVarName] || 0;
       result.cssVars[cssVarName]++;
+      // Track for _all.json && _all_sorted.json reports
       patternflyAggs.cssVars[cssVarName] = patternflyAggs.cssVars[cssVarName] || 0;
       patternflyAggs.cssVars[cssVarName]++;
-      // update productUsage
-      productUsage.cssVars[cssVarName] = productUsage.cssVars[cssVarName] || {};
-      productUsage.cssVars[cssVarName][repoName] = productUsage.cssVars[cssVarName][repoName] || [];
-      if (!productUsage.cssVars[cssVarName][repoName].includes(fileName)) {
-        productUsage.cssVars[cssVarName][repoName].push(fileName);
+      // Track for _all_product_uses.json report
+      productUsage.cssVars[cssVarName] = productUsage.cssVars[cssVarName] || {
+        "product_count": 0,
+        "total_usage": 0
+      };
+      let varDataObj = productUsage.cssVars[cssVarName];
+      if (!varDataObj[repoName]) {
+        varDataObj[repoName] = { "repo_usage": 0 };
+        // Tally total number of unique products (by repoName)
+        varDataObj.product_count++;
       }
+      // Track which files, and how many times, where cssVarName is used per repo
+      varDataObj[repoName][fileName] = varDataObj[repoName][fileName] || 0;
+      varDataObj[repoName][fileName]++;
+      varDataObj[repoName].repo_usage++;
+      varDataObj.total_usage++;
     }
 
     matchClasses(contents, file);

--- a/src/static-analysis/getSortedImports.js
+++ b/src/static-analysis/getSortedImports.js
@@ -56,6 +56,29 @@ const getSortedImports = (importsObj) => {
   return sortedCategories;
 }
 
+const sortUsageSection = (usageObj) => Object
+  .entries(usageObj)
+  .sort((
+    [_pfItemName1, pfItemData1],
+    [_pfItemName2, pfItemData2]
+  ) => pfItemData2.product_count - pfItemData1.product_count)
+  .reduce((acc, [curPfItemName, curPfItemData]) => {
+    acc[curPfItemName] = curPfItemData;
+    return acc;
+  }, {});
+
+// Sort productUsage sections by product_count
+const getSortedUsage = (productUsageObj) => {
+  const sortedResult = {};
+  console.log('GET SORTED USAGE');
+  Object.entries(productUsageObj).map(([sectionName, sectionData]) => {
+    const sortedSection = sortUsageSection(sectionData);
+    sortedResult[sectionName] = sortedSection;
+  });
+  return sortedResult;
+}
+
 module.exports = {
-  getSortedImports
+  getSortedImports,
+  getSortedUsage
 }


### PR DESCRIPTION
Closes #29 
Closes #30 

This PR:
- replaces deprecated `.substr` with `.substring`
- fixes bugs in `classRegex` && `varRegex` regex used to report on PF classes & CSS variables in `getPatternflyStats`
- update `Fuse-Online(Syndesis)` repo name to `Fuse-Online-Syndesis` due to error thrown due to directory name containing parenthesis
- adds new `_all_product_uses` report which:
  - tracks both the total number of uses (`total_usage`) and the unique number of products /repos (`product_count`) using a given item, and sorts by highest `product_count`
  - Tracks the total number of uses of each PF item for each repo (`repo_usage`), along with the number of unique import paths used to import each component (`unique_import_paths`)
  - Tracks the specific files within each repo where each PF item is used
  - example of this full report can be [seen here](https://gist.github.com/evwilkin/6c3075e3923e561bc3f78f97558b6d68#file-_all_product_uses-json)

This new report should help:
- identify component popularity based on # of products using it, vs. one product using it heavily & skewing the data
- give immediate file list for debugging any errors for a given component in a given product
- enable PF team to proactively target & alert users of a given component about upcoming changes, such as any breaking changes to Beta components in use, as well as point them to where any related changes should be made.