### PR TITLE
fix(repos): Remove keycloak-ui from repos.json

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -246,10 +246,6 @@
       "name": "Ansible-ui"
     },
     {
-      "git": "https://github.com/keycloak/keycloak-ui",
-      "name": "Keycloak-ui"
-    },
-    {
       "git": "https://github.com/openshift-assisted/assisted-ui-lib",
       "name": "Openshift-assisted-ui"
     },


### PR DESCRIPTION
Closes #38 

This PR removes `keycloak-ui` from repos.json as this repo no longer exists and causes the analytics to error out.  The code that was located here is still captured within the existing keycloak repo listed elsewhere in repos.json.