### PR TITLE
chore(repos): update nmstate-console-plugin url

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -334,7 +334,7 @@
       "name": "RHEnVision"
     },
     {
-      "git": "https://github.com/nmstate/nmstate-console-plugin",
+      "git": "https://github.com/openshift/nmstate-console-plugin",
       "name": "Nmstate-plugin"
     },
     {


### PR DESCRIPTION
Closes #58 

This PR updates the URL for the nmstate-console-plugin repo as it's moved github orgs.