### PR TITLE
chore: add Lightspeed Core reference UI repo to analytics tracking

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -445,6 +445,10 @@
       "git": "https://gitlab.cee.redhat.com/gss-engineering/portal-case-management",
       "name": "Portal-Case-Management",
       "private": true
+    },
+    {
+      "git": "https://github.com/lightspeed-core/lightspeed-reference-ui",
+      "name": "Lightspeed-Core-Reference-UI"
     }
   ]
 }


### PR DESCRIPTION
Closes #95 

This PR adds the `Lightspeed-Core-Reference-UI` repo from the list of Chatbot consumers.  All other repos are already tracked or archived.