### PR TITLE
chore: add untracked PatternFly repos and Jira discovery skill

### DIFF
--- a/.cursor/skills/discover-patternfly-repos/SKILL.md
+++ b/.cursor/skills/discover-patternfly-repos/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: discover-patternfly-repos
+description: This skill should be used when the user asks to "discover repos", "find patternfly repos", "what repos are missing", "search jira for patternfly", "untracked repos", "repos not in repos.json", "find new products using patternfly", or wants to identify codebases using PatternFly that are not yet tracked in this analytics project.
+---
+
+# Discover PatternFly Repos
+
+Identify products and codebases using PatternFly that are not yet tracked in `repos.json`. Search Jira for PatternFly references to find product teams, then search GitHub for their public repositories, and cross-reference against currently tracked repos.
+
+This is an MCP-driven workflow — use the Atlassian Jira MCP and GitHub MCP tools directly. No standalone script.
+
+## Step 1: Load Currently Tracked Repos
+
+Read `repos.json` from the project root. Extract all `git` URLs and build a lookup set of `org/repo` pairs (e.g. `RedHatInsights/ros-frontend`) for comparison. Count total tracked repos for the report.
+
+## Step 2: Search Jira for PatternFly References
+
+Use `mcp__mcp-atlassian__jira_search` with these JQL queries. Run them in parallel where possible. Paginate using `page_token` until no more results.
+
+**Primary queries (run in parallel):**
+
+```
+summary ~ "patternfly" ORDER BY project ASC
+labels in ("patternfly", "PatternFly", "pf5", "pf6", "patternfly-upgrade", "patternfly-migration") ORDER BY project ASC
+text ~ "patternfly" ORDER BY project ASC
+```
+
+Use `limit: 50` and `fields: "summary,project,labels,status,issuetype"` for each query.
+
+**Extract from each result:**
+- `project.key` (e.g. "AAP")
+- `project.name` (e.g. "Ansible Automation Platform")
+- `project.category` (e.g. "Ansible Automation Platform")
+
+Deduplicate projects across all queries by `project.key`.
+
+## Step 3: Filter Jira Projects
+
+Remove projects that are not product codebases. Skip projects matching these criteria:
+
+**Skip categories:** `UIE-UXD` (UX design teams)
+
+**Skip project names containing:** "UX Research", "UXD Research", "Feedback", "ADR", "Documentation", "Strategy"
+
+**Skip project types:** Projects that are purely design, research, feedback trackers, or architecture decision records — they reference PatternFly but have no codebase to track.
+
+For remaining projects, check if they map to repos already in `repos.json` (by matching project name/key to existing repo names). Separate into "already tracked" and "not tracked" lists.
+
+## Step 4: Search GitHub for Untracked Projects
+
+For projects not already tracked, search GitHub for their codebases.
+
+**Approach A — Search by product name:**
+Use `mcp__github__search_repositories` with product-relevant terms from the Jira project name.
+
+**Approach B — Broad org code search (more thorough):**
+Search for `@patternfly/react-core` in `package.json` across major Red Hat GitHub orgs. Run these in parallel:
+
+```
+@patternfly/react-core filename:package.json org:RedHatInsights
+@patternfly/react-core filename:package.json org:openshift
+@patternfly/react-core filename:package.json org:redhat-developer
+@patternfly/react-core filename:package.json org:cockpit-project
+@patternfly/react-core filename:package.json org:ansible
+@patternfly/react-core filename:package.json org:kubevirt-ui
+@patternfly/react-core filename:package.json org:red-hat-storage
+```
+
+Use `mcp__github__search_code` with `perPage: 30`.
+
+Extract unique `full_name` (org/repo) from results. Compare against tracked repos set from Step 1.
+
+**For each untracked repo found**, fetch metadata via `mcp__github__search_repositories` with query `repo:ORG/REPO` to get: `archived`, `language`, `pushed_at`, `updated_at`, `description`.
+
+## Step 5: Classify Untracked Repos
+
+Categorize each untracked repo into tiers based on metadata:
+
+| Tier | Criteria |
+|------|----------|
+| **Tier 1** | Not archived, pushed within last 6 months, TypeScript or JavaScript language |
+| **Tier 2** | Not archived, pushed 6-24 months ago, or non-JS language with PF usage |
+| **Archived** | `archived: true` on GitHub |
+| **Stale** | Not archived but no push in 2+ years |
+| **Private/Internal** | Jira project references PatternFly but no public GitHub repo found |
+
+Exclude repos that are clearly templates, test fixtures, starter apps, or documentation-only (check description and name for "template", "starter", "seed", "demo", "test", "docs", "guides").
+
+## Step 6: Generate Report
+
+Output a markdown report with this structure:
+
+```markdown
+## PatternFly Repo Discovery Report
+
+**Date:** [today]
+**Currently tracked:** [count] repos in repos.json
+**Jira projects found:** [count] unique projects referencing PatternFly
+**New repos discovered:** [count]
+
+### Tier 1 — Active, public, confirmed PatternFly usage
+| Repo | Description | Jira Project | Language | Last Push |
+|------|------------|--------------|----------|-----------|
+
+#### Ready to add to repos.json
+\```json
+{"git": "https://github.com/org/repo", "name": "Display-Name"},
+\```
+
+### Tier 2 — Less active or unconfirmed
+| Repo | Description | Language | Last Push |
+|------|------------|----------|-----------|
+
+### Archived (skip)
+| Repo | Description |
+|------|------------|
+
+### Stale (no activity 2+ years)
+| Repo | Last Push |
+|------|-----------|
+
+### Private/Internal (Jira only, no public repo found)
+| Jira Key | Project Name | Category | Signal |
+|----------|-------------|----------|--------|
+
+### Already tracked in repos.json
+[Count] Jira projects map to repos already in repos.json: [list keys]
+```
+
+Generate `repos.json` entries for Tier 1 repos using the naming convention from existing entries (e.g. `RedHatInsights-` prefix, `Openshift-` prefix, hyphenated display names).
+
+Do **not** modify `repos.json` unless the user explicitly asks to add entries.
+
+## Additional Resources
+
+- **`references/jira-queries.md`** — Full JQL reference, GitHub org list, skip-list details, and field mappings

--- a/.cursor/skills/discover-patternfly-repos/references/jira-queries.md
+++ b/.cursor/skills/discover-patternfly-repos/references/jira-queries.md
@@ -1,0 +1,136 @@
+# Jira & GitHub Query Reference
+
+## JQL Queries
+
+### Primary queries (run in parallel, paginate all)
+
+```sql
+-- Issues with "patternfly" in summary
+summary ~ "patternfly" ORDER BY project ASC
+
+-- Issues labeled with PatternFly-related labels
+labels in ("patternfly", "PatternFly", "pf5", "pf6", "patternfly-upgrade", "patternfly-migration", "PF6-Adoption", "patternfly6") ORDER BY project ASC
+
+-- Full-text search (broadest, catches description/comments)
+text ~ "patternfly" ORDER BY project ASC
+```
+
+### MCP tool parameters
+
+```json
+{
+  "jql": "summary ~ \"patternfly\" ORDER BY project ASC",
+  "fields": "summary,project,labels,status,issuetype",
+  "limit": 50
+}
+```
+
+Paginate using `page_token` from previous response. Continue until response has no `next_page_token`.
+
+### Key fields to extract
+
+| Field | Path | Example |
+|-------|------|---------|
+| Project key | `issue.project.key` | `AAP` |
+| Project name | `issue.project.name` | `Ansible Automation Platform` |
+| Project category | `issue.project.category` | `Ansible Automation Platform` |
+
+## Projects to Skip
+
+### By category
+- `UIE-UXD` — UX design teams, not product codebases
+
+### By project name patterns
+Skip projects whose name contains:
+- "UX Research", "UXD Research"
+- "Feedback"
+- "ADR" (architecture decision records)
+- "Documentation"
+- "Strategy"
+- "Applied AI UX"
+
+### Known non-product project keys
+| Key | Name | Why skip |
+|-----|------|----------|
+| AUX | Applied AI UX | UXD design project |
+| CPUX | Core Platforms UX | UXD design project |
+| HPUX | Hybrid Platforms User Experience | UXD design project |
+| UXDR | UXD Research | Research project |
+| CRCFEEDBK | Clouddot Feedback | Feedback tracker |
+| ADR | ConsoleDot ADR | Architecture records |
+| BXMSDOC | BxMS Documentation | Documentation |
+| CONTENT | Content Testing | Content testing |
+| ANSTRAT | Ansible Strategy | Strategy, covered by AAP |
+| OCPBUGS | OpenShift Bugs | Bug tracker, covered by openshift/console |
+
+## GitHub Organizations to Search
+
+Search `@patternfly/react-core filename:package.json` in these orgs:
+
+| Org | Products covered |
+|-----|-----------------|
+| `RedHatInsights` | ConsoleDot / Hybrid Cloud Console apps |
+| `openshift` | OpenShift console + plugins |
+| `redhat-developer` | Developer Hub, GitOps, Helm plugins |
+| `cockpit-project` | Cockpit and related plugins |
+| `ansible` | Ansible tooling UIs |
+| `ansible-automation-platform` | AAP UI |
+| `kubevirt-ui` | KubeVirt plugin |
+| `red-hat-storage` | ODF console |
+| `konveyor` | Migration toolkits |
+| `opendatahub-io` | ODH dashboard |
+| `red-hat-data-services` | RH Data Services |
+| `stackrox` | ACS / StackRox |
+| `hawtio` | Hawtio consoles |
+| `kiali` | Kiali / Service Mesh |
+| `openshift-pipelines` | Pipelines console plugin |
+| `openshift-assisted` | Assisted installer |
+| `skupperproject` | Skupper console |
+| `netobserv` | Network observability |
+| `artemiscloud` | AMQ Broker console |
+| `EnMasseProject` | AMQ messaging |
+| `Kuadrant` | Kuadrant console plugin |
+| `freeipa` | FreeIPA Web UI |
+| `cryostatio` | Cryostat Web |
+| `infinispan` | Infinispan console |
+| `patternfly` | PF seed/templates |
+| `quay` | Quay |
+| `Apicurio` | Apicurio Registry |
+| `lightspeed-core` | Lightspeed Reference UI |
+| `redhat-composer-ai` | Composer AI chatbot |
+| `rh-aiservices-bu` | RH AI Services |
+| `rh-ai-kickstart` | RH AI Kickstart |
+| `RedHat-UX` | RedHat UX |
+
+## Repo Name Convention
+
+When generating `repos.json` entries, follow existing naming patterns:
+
+| Org | Name prefix | Example |
+|-----|------------|---------|
+| `RedHatInsights/*` | `RedHatInsights-` | `RedHatInsights-ros-frontend` |
+| `openshift/*` | `Openshift-` | `Openshift-mirror-gui` |
+| `redhat-developer/*` | `Redhat-developer-` | `Redhat-developer-gitops-console-plugin` |
+| `cockpit-project/*` | `Cockpit-` | `Cockpit-machines` |
+| Other | Product name, hyphenated | `Kiali`, `Quay`, `Infinispan` |
+
+## Exclusion Patterns for Repos
+
+Skip repos whose name or description match:
+- `*-template`, `*-seed`, `*-starter*`, `*-demo`
+- `*-test`, `*-common-test`
+- `*-guides`, `*-docs`
+- `frontend-assets`, `frontend-common-test`
+- `logger-demo`
+- `ci-tools`
+- `*-backend` (unless it has a frontend subfolder)
+
+## Tiering Criteria
+
+| Tier | Archived? | Last push | Language | PF confirmed? |
+|------|-----------|-----------|----------|---------------|
+| Tier 1 | No | < 6 months | TS/JS | Yes (package.json) |
+| Tier 2 | No | 6-24 months | Any | Yes or likely |
+| Archived | Yes | Any | Any | Any |
+| Stale | No | > 24 months | Any | Any |
+| Private | N/A | N/A | N/A | Jira refs only |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,13 @@ node src/github-dependents-analyzer.js --repo-url https://github.com/patternfly/
 node src/github-dependents-analyzer.js --repo-url https://github.com/patternfly/patternfly-react --create-pr
 ```
 
+### Discover untracked PatternFly repos (Jira + GitHub)
+Ask Claude: "discover repos not tracked in repos.json" or "find patternfly repos"
+- Uses Jira MCP to search for PatternFly references across all projects
+- Uses GitHub MCP to find public repos with @patternfly dependencies
+- Cross-references against repos.json and produces a tiered report
+- Skill definition: `.cursor/skills/discover-patternfly-repos/SKILL.md`
+
 ### Repository list health (archived / stale)
 ```bash
 npm run review-repos-health              # Markdown report; requires gh or GITHUB_TOKEN; GITLAB_TOKEN for GitLab

--- a/repos.json
+++ b/repos.json
@@ -449,6 +449,46 @@
     {
       "git": "https://github.com/lightspeed-core/lightspeed-reference-ui",
       "name": "Lightspeed-Core-Reference-UI"
+    },
+    {
+      "git": "https://github.com/openshift/genie-web-client",
+      "name": "Aladdin-Genie-Web-Client"
+    },
+    {
+      "git": "https://github.com/openshift/cluster-update-console-plugin",
+      "name": "Openshift-cluster-update-console-plugin"
+    },
+    {
+      "git": "https://github.com/openshift/mirror-gui",
+      "name": "Openshift-mirror-gui"
+    },
+    {
+      "git": "https://github.com/openshift/console-dashboards-plugin",
+      "name": "Openshift-console-dashboards-plugin"
+    },
+    {
+      "git": "https://github.com/RedHatInsights/ros-frontend",
+      "name": "RedHatInsights-ros-frontend"
+    },
+    {
+      "git": "https://github.com/RedHatInsights/subscription-inventory-ui",
+      "name": "RedHatInsights-subscription-inventory-ui"
+    },
+    {
+      "git": "https://github.com/RedHatInsights/cloud-inventory-ui",
+      "name": "RedHatInsights-cloud-inventory-ui"
+    },
+    {
+      "git": "https://github.com/RedHatInsights/widget-layout",
+      "name": "RedHatInsights-widget-layout"
+    },
+    {
+      "git": "https://github.com/RedHatInsights/dbaas-ui",
+      "name": "RedHatInsights-dbaas-ui"
+    },
+    {
+      "git": "https://github.com/openshift/vcf-migration-operator",
+      "name": "Openshift-vcf-migration-operator"
     }
   ]
 }


### PR DESCRIPTION
Closes #100 

## Summary
- Add 10 new repos discovered via Jira PatternFly cross-referencing (OpenShift plugins, RedHatInsights frontends)
- Add `discover-patternfly-repos` skill that automates searching Jira + GitHub for untracked PatternFly-consuming repos
- Document the new skill in CLAUDE.md

## Test plan
- [ ] Run `npm run collect` to verify new repos clone and scan correctly
- [ ] Trigger skill with "discover repos not tracked in repos.json" and verify tiered report output
- [ ] Confirm new repos appear in analytics output files

🤖 Generated with [Claude Code](https://claude.com/claude-code)