### PR TITLE
chore: add missing OpenShift console plugins

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -489,6 +489,22 @@
     {
       "git": "https://github.com/openshift/vcf-migration-operator",
       "name": "Openshift-vcf-migration-operator"
+    },
+    {
+      "git": "https://github.com/stolostron/console",
+      "name": "Stolostron-ACM-MCE-console"
+    },
+    {
+      "git": "https://github.com/medik8s/node-remediation-console",
+      "name": "Node-remediation-console"
+    },
+    {
+      "git": "https://github.com/redhat-developer/helm-console-plugin",
+      "name": "Redhat-developer-helm-console-plugin"
+    },
+    {
+      "git": "https://github.com/cryostatio/cryostat-openshift-console-plugin",
+      "name": "Cryostat-openshift-console-plugin"
     }
   ]
 }


### PR DESCRIPTION
Closes #102 

## Summary
- Cross-referenced a shared OpenShift console plugin inventory against `repos.json` (see [Slack thread](https://redhat-internal.slack.com/archives/C011BL0FEKZ/p1776880284347009))
- Added 4 previously untracked console plugins:
  - `stolostron/console` (ACM + MCE plugins)
  - `medik8s/node-remediation-console` (Node Health Check Operator)
  - `redhat-developer/helm-console-plugin` (Helm)
  - `cryostatio/cryostat-openshift-console-plugin` (Cryostat console plugin, separate from cryostat-web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)